### PR TITLE
feat: add country text box instead of dropdown, address is not getting pre-populated in quote if there any address is present at a particular b2b account, handle refresh grid and api request failure on clicking on submit for approval

### DIFF
--- a/components/b2b/QuotesTable/QuotesTable.tsx
+++ b/components/b2b/QuotesTable/QuotesTable.tsx
@@ -275,7 +275,7 @@ const QuotesTable = (props: QuotesTableProps) => {
                 ))}
             </TableRow>
           </TableHead>
-          {quotes?.length === 0 ? (
+          {!quotes || quotes?.length === 0 ? (
             <caption>{t('no-quotes-found')}</caption>
           ) : (
             <TableBody data-testid="quotes-table-body">

--- a/components/common/AddressForm/AddressForm.tsx
+++ b/components/common/AddressForm/AddressForm.tsx
@@ -45,7 +45,10 @@ export const useFormSchema = () => {
         is: CountryCode.US || CountryCode.CA,
         then: yup.string().required(t('this-field-is-required')).min(4, t('enter-valid-zip-code')),
       }),
-      countryCode: yup.string().required(t('this-field-is-required')),
+      countryCode: yup
+        .string()
+        .required('This field is required')
+        .matches(/^[A-Z]{2}$/i, t('enter-valid-country-code')),
     }),
     phoneNumbers: yup.object().shape({
       home: yup.string().required(t('this-field-is-required')),
@@ -276,23 +279,20 @@ const AddressForm = (props: AddressFormProps) => {
           <Controller
             name="address.countryCode"
             control={control}
-            defaultValue={
-              contact?.address?.countryCode || countries.length === 1 ? countries[0] : ''
-            }
+            defaultValue={contact?.address?.countryCode}
             render={({ field }) => (
               <div>
-                <KiboSelect
-                  name="country-code"
+                <KiboTextBox
+                  {...field}
+                  value={field.value || ''}
                   label={t('country-code')}
-                  value={field.value}
+                  ref={null}
                   error={!!errors?.address?.countryCode}
                   helperText={errors?.address?.countryCode?.message}
-                  onChange={(_name, value) => field.onChange(value)}
+                  onChange={(_name, value) => field.onChange(value.toUpperCase())}
                   onBlur={field.onBlur}
                   required={true}
-                >
-                  {generateSelectOptions()}
-                </KiboSelect>
+                />
               </div>
             )}
           />

--- a/components/page-templates/B2B/QuoteDetailsTemplate/QuoteDetailsTemplate.tsx
+++ b/components/page-templates/B2B/QuoteDetailsTemplate/QuoteDetailsTemplate.tsx
@@ -250,16 +250,14 @@ const QuoteDetailsTemplate = (props: QuoteDetailsTemplateProps) => {
     pickupItems
   )
 
-  const userShippingAddress = isAuthenticated
-    ? userGetters.getUserShippingAddress(addressCollection?.items as CustomerContact[])
-    : []
+  const b2bAccountShippingAddress = userGetters.getUserShippingAddress(b2bAccount?.contacts)
 
   const [savedShippingAddresses, setSavedShippingAddresses] = useState<
     CustomerContact[] | undefined
   >(
     userGetters.getAllShippingAddresses(
       quoteShippingContact,
-      userShippingAddress as CustomerContact[]
+      b2bAccountShippingAddress as CustomerContact[]
     )
   )
   const showPreviouslySavedAddress = savedShippingAddresses && savedShippingAddresses.length > 0
@@ -381,14 +379,17 @@ const QuoteDetailsTemplate = (props: QuoteDetailsTemplateProps) => {
       showModal({
         Component: ConfirmationDialog,
         props: {
-          onConfirm: () => {
-            updateQuote.mutate({
+          onConfirm: async () => {
+            const response = await updateQuote.mutateAsync({
               quoteId,
               updateMode: QuoteUpdateMode.ApplyAndCommit,
               name: quote?.name as string,
               expirationDate: quote?.expirationDate,
+              status: quote?.status as string,
             })
-            onAccountTitleClick()
+            if (response?.id) {
+              onAccountTitleClick()
+            }
           },
           title: isApproving ? t('approve-quote-title') : t('submit-quote-title'),
           contentText: isApproving
@@ -671,10 +672,14 @@ const QuoteDetailsTemplate = (props: QuoteDetailsTemplateProps) => {
     setSavedShippingAddresses(
       userGetters.getAllShippingAddresses(
         quoteShippingContact,
-        userShippingAddress as CustomerContact[]
+        b2bAccountShippingAddress as CustomerContact[]
       )
     )
-  }, [JSON.stringify(quoteShippingContact), JSON.stringify(userShippingAddress), isNewAddressAdded])
+  }, [
+    JSON.stringify(quoteShippingContact),
+    JSON.stringify(b2bAccountShippingAddress),
+    isNewAddressAdded,
+  ])
 
   useEffect(() => {
     setQuoteNameInputValue(quote?.name ? quote?.name : '')

--- a/hooks/mutations/b2b/quotes/useUpdateQuote/useUpdateQuote.ts
+++ b/hooks/mutations/b2b/quotes/useUpdateQuote/useUpdateQuote.ts
@@ -19,12 +19,13 @@ interface UpdateQuoteProps {
   updateMode: string
   name?: string
   expirationDate?: string
+  status?: string
 }
 const updateQuote = async (props: UpdateQuoteProps): Promise<Quote> => {
   const client = makeGraphQLClient()
-  const { quoteId, updateMode, name, expirationDate } = props
+  const { quoteId, updateMode, name, expirationDate, status } = props
 
-  const variables = buildUpdateQuoteParams(quoteId, updateMode, name, expirationDate)
+  const variables = buildUpdateQuoteParams(quoteId, updateMode, name, expirationDate, status)
 
   const response = await client.request({
     document: updateQuoteMutation,

--- a/lib/gql/queries/b2b/get-b2b-account.ts
+++ b/lib/gql/queries/b2b/get-b2b-account.ts
@@ -2,6 +2,32 @@ const getB2BAccount = /* GraphQL */ `
   query b2bAccount($accountId: Int!) {
     b2bAccount(accountId: $accountId) {
       companyOrOrganization
+      contacts {
+        id
+        accountId
+        firstName
+        lastNameOrSurname
+        middleNameOrInitial
+        types {
+          name
+          isPrimary
+        }
+        address {
+          address1
+          address2
+          addressType
+          cityOrTown
+          countryCode
+          isValidated
+          postalOrZipCode
+          stateOrProvince
+        }
+        phoneNumbers {
+          home
+          mobile
+          work
+        }
+      }
       users {
         firstName
         lastName

--- a/lib/helpers/buildUpdateQuoteParams.ts
+++ b/lib/helpers/buildUpdateQuoteParams.ts
@@ -4,7 +4,8 @@ export const buildUpdateQuoteParams = (
   quoteId: string,
   updateMode: string,
   name?: string,
-  expirationDate?: string
+  expirationDate?: string,
+  status?: string
 ): MutationUpdateQuoteArgs => {
   return {
     quoteId,
@@ -33,6 +34,7 @@ export const buildUpdateQuoteParams = (
       handlingTotal: 0,
       dutyTotal: 0,
       feeTotal: 0,
+      status,
     },
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -540,5 +540,5 @@
   "approve-quote-with-changes": "Approve quote with changes",
   "digital-products-shipping-text": "No shipping information is required since all items will be picked up in the store or digitally fulfilled.",
   "digital-products": "Digital Products",
-  "enter-valid-country-code": "Country Code must be a two-letter, e.g. US."
+  "enter-valid-country-code": "The country code must be two letters."
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -539,5 +539,6 @@
   "all-quotes": "All Quotes",
   "approve-quote-with-changes": "Approve quote with changes",
   "digital-products-shipping-text": "No shipping information is required since all items will be picked up in the store or digitally fulfilled.",
-  "digital-products": "Digital Products"
+  "digital-products": "Digital Products",
+  "enter-valid-country-code": "Country Code must be a two-letter, e.g. US."
 }


### PR DESCRIPTION
1. icky-980
  Add country text box instead of dropdown
  Address is not getting pre-populated in quote if there any address is present at a particular b2b account

2. icky-979
    Handle refresh grid and API request failure on clicking on Submit for Approval